### PR TITLE
Add OLM manifests

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -44,8 +44,12 @@ spec:
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
-            - name: device-dir
-              mountPath: /dev
+            - name: efs-state-dir
+              mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /var/amazon/efs
+            - name: efs-utils-config-legacy
+              mountPath: /etc/amazon/efs-legacy
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on all nodes!
@@ -115,8 +119,15 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
             type: Directory
-        - name: device-dir
+        - name: efs-state-dir
           hostPath:
-            path: /dev
-            type: Directory
-
+            path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /var/amazon/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config-legacy
+          hostPath:
+            path: /etc/amazon/efs
+            type: DirectoryOrCreate

--- a/manifests/4.9/aws-efs-csi-driver-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/aws-efs-csi-driver-operator.v4.9.0.clusterserviceversion.yaml
@@ -1,0 +1,314 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: aws-efs-csi-driver-operator.v4.9.0
+  namespace: placeholder
+  annotations:
+    # This example is useless, because the operator does not have its own CRD, OCP console won't offer it as a CR.
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.openshift.io/v1",
+          "kind": "ClusterCSIDriver",
+          "metadata": {
+            "name": "efs.csi.aws.com"
+          },
+          "spec": {
+            "logLevel": "Normal",
+            "managementState": "Managed",
+            "operatorLogLevel": "Normal"
+          }
+        }
+      ]
+    categories: Storage
+    "operatorframework.io/suggested-namespace": openshift-cluster-csi-drivers
+    capabilities: Full Lifecycle
+    containerImage: quay.io/openshift/origin-aws-efs-csi-driver-operator:latest
+    support: Red Hat
+    repository: https://github.com/openshift/aws-efs-csi-driver-operator
+    createdAt: "2021-07-14T00:00:00Z"
+    description: Install and configure AWS EFS CSI driver.
+    olm.skipRange: ">=4.3.0 <4.9.0"
+  labels:
+    operator-metering: "true"
+    "operatorframework.io/arch.amd64": supported
+spec:
+  displayName: AWS EFS CSI Driver Operator
+  description: Operator that installs and configures the CSI driver for Amazon Elastic File System (AWS EFS).
+  keywords:
+    - storage
+    - efs
+  links:
+    - name: Documentation
+      url: https://github.com/openshift/aws-efs-csi-driver-operator
+    - name: Source Repository
+      url: https://github.com/openshift/aws-efs-csi-driver-operator
+  version: 4.9.0
+  maturity: stable
+  maintainers:
+    - email: aos-storage-staff@redhat.com
+      name: Red Hat
+  minKubeVersion: 1.21.0
+  provider:
+    name: Red Hat
+  labels:
+    alm-owner-metering: aws-efs-csi-driver-operator
+    alm-status-descriptors: aws-efs-csi-driver-operator.v4.9.0
+  selector:
+    matchLabels:
+      alm-owner-metering: aws-efs-csi-driver-operator
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - rules:
+          - apiGroups:
+            - ''
+            resources:
+            - pods
+            - services
+            - endpoints
+            - events
+            - configmaps
+            - secrets
+            verbs:
+            - '*'
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            - daemonsets
+            - replicasets
+            verbs:
+            - '*'
+          serviceAccountName: aws-efs-csi-driver-operator
+      clusterPermissions:
+        - rules:
+          - apiGroups:
+            - security.openshift.io
+            resourceNames:
+            - privileged
+            resources:
+            - securitycontextconstraints
+            verbs:
+            - use
+          - apiGroups:
+            - operator.openshift.io
+            resources:
+            - clustercsidrivers
+            verbs:
+            - get
+            - list
+            - watch
+            # The Config Observer controller updates the CR's spec
+            - update
+            - patch
+          - apiGroups:
+            - operator.openshift.io
+            resources:
+            - clustercsidrivers/status
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+            - patch
+          - apiGroups:
+            - ''
+            resourceNames:
+            - extension-apiserver-authentication
+            - aws-ebs-csi-driver-operator-lock
+            resources:
+            - configmaps
+            verbs:
+            - '*'
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterroles
+            - clusterrolebindings
+            - roles
+            - rolebindings
+            verbs:
+            - watch
+            - list
+            - get
+            - create
+            - delete
+            - patch
+            - update
+          - apiGroups:
+            - ''
+            resources:
+            - serviceaccounts
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+          - apiGroups:
+            - coordination.k8s.io
+            resources:
+            - leases
+            verbs:
+            - '*'
+          - apiGroups:
+            - ''
+            resources:
+            - secrets
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ''
+            resources:
+            - persistentvolumes
+            verbs:
+            - create
+            - delete
+            - list
+            - get
+            - watch
+            - update
+            - patch
+          - apiGroups:
+            - ''
+            resources:
+            - persistentvolumeclaims
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - volumeattachments
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+            - delete
+            - create
+            - patch
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - volumeattachments/status
+            verbs:
+            - patch
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - storageclasses
+            - csinodes
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - delete
+          - apiGroups:
+            - '*'
+            resources:
+            - events
+            verbs:
+            - get
+            - patch
+            - create
+            - list
+            - watch
+            - update
+            - delete
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - csidrivers
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - delete
+          - apiGroups:
+            - cloudcredential.openshift.io
+            resources:
+            - credentialsrequests
+            verbs:
+            - '*'
+          - apiGroups:
+            - config.openshift.io
+            resources:
+            - infrastructures
+            - proxies
+            verbs:
+            - get
+            - list
+            - watch
+          serviceAccountName: aws-efs-csi-driver-operator
+      deployments:
+        - name: aws-efs-csi-driver-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: aws-efs-csi-driver-operator
+            template:
+              metadata:
+                annotations:
+                  target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                labels:
+                  app: aws-efs-csi-driver-operator
+              spec:
+                serviceAccountName: aws-efs-csi-driver-operator
+                containers:
+                - name: aws-efs-csi-driver-operator
+                  image: quay.io/openshift/origin-aws-efs-csi-driver-operator:latest
+                  imagePullPolicy: IfNotPresent
+                  args:
+                    - "start"
+                    - "-v=2"
+                  env:
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: DRIVER_IMAGE
+                      value: quay.io/openshift/origin-aws-efs-csi-driver:latest
+                    - name: PROVISIONER_IMAGE
+                      value: quay.io/openshift/origin-csi-external-provisioner:latest
+                    - name: NODE_DRIVER_REGISTRAR_IMAGE
+                      value: quay.io/openshift/origin-csi-node-driver-registrar:latest
+                    - name: LIVENESS_PROBE_IMAGE
+                      value: quay.io/openshift/origin-csi-livenessprobe:latest
+                    - name: OPERATOR_NAME
+                      value: aws-efs-csi-driver-operator
+                  resources:
+                    requests:
+                      memory: 50Mi
+                      cpu: 10m
+                priorityClassName: system-cluster-critical
+                nodeSelector:
+                  node-role.kubernetes.io/master: ""
+                tolerations:
+                  - key: CriticalAddonsOnly
+                    operator: Exists
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+                    effect: "NoSchedule"

--- a/manifests/4.9/image-references
+++ b/manifests/4.9/image-references
@@ -1,0 +1,25 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: aws-efs-csi-driver-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-aws-efs-csi-driver-operator:latest
+  - name: aws-efs-csi-driver
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-aws-efs-csi-driver:latest
+  - name: csi-external-provisioner
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-external-provisioner
+  - name: csi-node-driver-registrar
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-node-driver-registrar
+  - name: csi-livenessprobe
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-livenessprobe:latest

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -1,0 +1,15 @@
+updates:
+  - file: "{MAJOR}.{MINOR}/aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    # replace metadata.name value
+    - search: "aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0"
+      replace: "aws-efs-csi-driver-operator.{FULL_VER}"
+    # replace entire version line, otherwise would replace 4.3.0 anywhere
+    - search: "version: {MAJOR}.{MINOR}.0"
+      replace: "version: {FULL_VER}"
+    - search: 'olm.skipRange: ">=4.9.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.9.0 <{FULL_VER}"'
+  - file: "aws-efs-csi-driver-operator.package.yaml"
+    update_list:
+    - search: "currentCSV: aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0"
+      replace: "currentCSV: aws-efs-csi-driver-operator.{FULL_VER}"

--- a/manifests/aws-efs-csi-driver-operator.package.yaml
+++ b/manifests/aws-efs-csi-driver-operator.package.yaml
@@ -1,0 +1,4 @@
+packageName: aws-efs-csi-driver-operator
+channels:
+- name: "4.9"
+  currentCSV: aws-efs-csi-driver-operator.v4.9.0


### PR DESCRIPTION
Add manifests for OLM. Tested on OCP 4.9, it installs the CSI driver operator and with the CR also the driver.

Few things to note:

* Since the operator / CSV does not have its own CRD, OCP console will not offer users to create a CR. They must create it via cmdline.
* The operator installs to `openshift-cluster-csi-drivers` namespace or, with user explicit action, to `openshift-operators` namespace. The operator can be installed only once in a cluster (unless heavy force is used)
