### PR TITLE
Sync hostpath volumes with the upstream DaemonSet

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -44,8 +44,12 @@ spec:
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
-            - name: device-dir
-              mountPath: /dev
+            - name: efs-state-dir
+              mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /var/amazon/efs
+            - name: efs-utils-config-legacy
+              mountPath: /etc/amazon/efs-legacy
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on all nodes!
@@ -115,8 +119,15 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
             type: Directory
-        - name: device-dir
+        - name: efs-state-dir
           hostPath:
-            path: /dev
-            type: Directory
-
+            path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /var/amazon/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config-legacy
+          hostPath:
+            path: /etc/amazon/efs
+            type: DirectoryOrCreate


### PR DESCRIPTION
The CSI driver needs some hostpath volumes to store its own state to be able to restart stunnels after driver pod restart (or update).

Without these volumes, stunnells are killed when the old driver pod is deleted and nothing restarts them, resulting in all NFS mounts to time out.

The hostpath volumes were taken from the [upstream CSI driver DaemonSet](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/deploy/kubernetes/base/node-daemonset.yaml#L59).

@openshift/storage 