### PR TITLE
[ART-3172] Fix manifests for ART builds

### DIFF
--- a/manifests/4.9/image-references
+++ b/manifests/4.9/image-references
@@ -3,14 +3,14 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: aws-efs-csi-driver-operator
+  - name: aws-efs-csi-driver-rhel8-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-aws-efs-csi-driver-operator:latest
-  - name: aws-efs-csi-driver
+      name: quay.io/openshift/origin-aws-efs-csi-driver-rhel8-operator:latest
+  - name: aws-efs-csi-driver-container-rhel8
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-aws-efs-csi-driver:latest
+      name: quay.io/openshift/origin-aws-efs-csi-driver-container-rhel8:latest
   - name: csi-external-provisioner
     from:
       kind: DockerImage


### PR DESCRIPTION
Couple issues I found while trying to test building it through ART.
With those changes applied, we managed to get the following successful builds in brew:

* operator: [ose-aws-efs-csi-driver-operator-container-v4.9.0-202107212116.p0.git.05d3f58.assembly.stream](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1669731)
* bundle: [ose-aws-efs-csi-driver-operator-bundle-container-v4.9.0.202107212116.p0.git.05d3f58.assembly.stream-1](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1669818)