### PR TITLE
Bug 1986419: Fix image-references

### DIFF
--- a/config/manifests/4.9/image-references
+++ b/config/manifests/4.9/image-references
@@ -6,19 +6,19 @@ spec:
   - name: aws-efs-csi-driver-rhel8-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-aws-efs-csi-driver-rhel8-operator:latest
+      name: quay.io/openshift/origin-aws-efs-csi-driver-operator:latest
   - name: aws-efs-csi-driver-container-rhel8
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-aws-efs-csi-driver-container-rhel8:latest
+      name: quay.io/openshift/origin-aws-efs-csi-driver:latest
   - name: csi-external-provisioner
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-csi-external-provisioner
+      name: quay.io/openshift/origin-csi-external-provisioner:latest
   - name: csi-node-driver-registrar
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-csi-node-driver-registrar
+      name: quay.io/openshift/origin-csi-node-driver-registrar:latest
   - name: csi-livenessprobe
     from:
       kind: DockerImage


### PR DESCRIPTION
image-references must be a complete string match ﻿to the referrer.
This is needed to avoid quay.io references in the downstream CSV.
