### PR TITLE
Bug 1986419: art.yaml: refer to correct filename

### DIFF
--- a/config/manifests/art.yaml
+++ b/config/manifests/art.yaml
@@ -1,5 +1,5 @@
 updates:
-  - file: "{MAJOR}.{MINOR}/aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
+  - file: "{MAJOR}.{MINOR}/aws-efs-csi-driver-operator.clusterserviceversion.yaml" # relative to this file
     update_list:
     # replace metadata.name value
     - search: "aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
This needs to match the actual file name present, which is `aws-efs-csi-driver-operator.clusterserviceversion.yaml`

(I'm guessing the version in the filename is not important to OLM, guess we'll find out. It's one less thing to have to update each minor release.)