### PR TITLE
Bug 1994973: Fix olm.skipRange and currentCSV

### DIFF
--- a/config/manifests/4.9/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/4.9/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     repository: https://github.com/openshift/aws-efs-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
-    olm.skipRange: ">=4.3.0 <4.9.0"
+    olm.skipRange: ">=4.9.0 <4.9.0"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported

--- a/config/manifests/aws-efs-csi-driver-operator.package.yaml
+++ b/config/manifests/aws-efs-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: aws-efs-csi-driver-operator
 channels:
 - name: "4.9"
-  currentCSV: aws-efs-csi-driver-operator
+  currentCSV: aws-efs-csi-driver-operator.v4.9.0


### PR DESCRIPTION
Currently, the replacements in art.yml are ineffective. With these
changes, they will produce good results.