### PR TITLE
Bug 2023571: Remove kube-rbac-proxy for driver metrics

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -98,28 +98,6 @@ spec:
             requests:
               memory: 50Mi
               cpu: 10m
-          # kube-rbac-proxy for csi-driver container.
-          # Provides https proxy for http-based csi-driver metrics.
-        - name: driver-kube-rbac-proxy
-          args:
-          - --secure-listen-address=0.0.0.0:9216
-          - --upstream=http://127.0.0.1:8216/
-          - --tls-cert-file=/etc/tls/private/tls.crt
-          - --tls-private-key-file=/etc/tls/private/tls.key
-          - --logtostderr=true
-          image: ${KUBE_RBAC_PROXY_IMAGE}
-          imagePullPolicy: IfNotPresent
-          ports:
-          - containerPort: 9216
-            name: driver-m
-            protocol: TCP
-          resources:
-            requests:
-              memory: 20Mi
-              cpu: 10m
-          volumeMounts:
-          - mountPath: /etc/tls/private
-            name: metrics-serving-cert
           # external-provisioner container
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
@@ -169,7 +147,6 @@ spec:
           volumeMounts:
           - mountPath: /etc/tls/private
             name: metrics-serving-cert
-          # external-attacher container
         - name: csi-liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           imagePullPolicy: IfNotPresent

--- a/assets/service.yaml
+++ b/assets/service.yaml
@@ -13,10 +13,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: provisioner-m
-  - name: driver-m
-    port: 447
-    protocol: TCP
-    targetPort: driver-m
   selector:
     app: aws-efs-csi-driver-controller
   sessionAffinity: None

--- a/assets/servicemonitor.yaml
+++ b/assets/servicemonitor.yaml
@@ -13,14 +13,6 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: aws-efs-csi-driver-controller-metrics.${NAMESPACE}.svc
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
-    path: /metrics
-    port: driver-m
-    scheme: https
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: aws-efs-csi-driver-controller-metrics.${NAMESPACE}.svc
   jobLabel: component
   selector:
     matchLabels:


### PR DESCRIPTION
The driver does not emit any metric.

cc @openshift/storage 