### PR TITLE
Add arm64 arch label to CSV

### DIFF
--- a/config/manifests/4.10/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/4.10/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -16,6 +16,7 @@ metadata:
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.arm64": supported
 spec:
   displayName: AWS EFS CSI Driver Operator
   description: Operator that installs and configures the CSI driver for Amazon Elastic File System (AWS EFS).


### PR DESCRIPTION
AWS is the first platform on which OpenShift on ARM is enabled. This label is needed for operators to be displayed in OperatorHub on non-x86 architectures.
