### PR TITLE
Bug 2028484: CSI driver's livenessprobe does not respect operator's loglevel

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -154,6 +154,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=10303
+            - --v=${LOG_LEVEL}
           securityContext:
             # The container needs to be privileged to be able to talk to the driver CSI socket, which was created by a privileged container
             privileged: true

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -99,6 +99,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=10304
+            - --v=${LOG_LEVEL}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
When log level is changed in clustercsidriver it needs to propagate to a liveness probe container as well through a value passed to --v argument.