### PR TITLE
Bug 2029521: Eliminate parallelism in external-provisioner

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -113,6 +113,7 @@ spec:
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
             - --v=${LOG_LEVEL}
             - --timeout=5m
+            - --worker-threads=1
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
Only one deletion / provisioning can happen at a time. This should
eliminate issues with deleting multiple volumes at the same time, where
stunnel/mount gets stuck.

~WIP: check if CI passes~

With 1 worker thread, the driver will provision +/- 1 PV per second. It can delete 1 PV every 1-3 seconds.