### PR TITLE
Bug 2049073: Fix proxy injection

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -71,7 +71,10 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	).WithManagementStateController(
 		operatorName,
 		true,
-	).WithLogLevelController().WithCSIDriverNodeService(
+	).WithLogLevelController().WithCSIConfigObserverController(
+		"AWSEFSDriverCSIConfigObserverController",
+		configInformers,
+	).WithCSIDriverNodeService(
 		"AWSEFSDriverNodeServiceController",
 		replaceNamespaceFunc(operatorNamespace),
 		"node.yaml",


### PR DESCRIPTION
By adding `CSIConfigObserverController` that adds proxy config into `ClusterCSIDriver.Spec.ObservedConfig`. There are already proxy hooks that add the proxy from `ObservedConfig` to the driver Deployment + DaemonSet.