### PR TITLE
Bug 2056638: [4.9] Eliminate parallelism

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -134,6 +134,7 @@ spec:
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
             - --v=${LOG_LEVEL}
+            - --timeout=5m
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -135,6 +135,7 @@ spec:
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
             - --v=${LOG_LEVEL}
             - --timeout=5m
+            - --worker-threads=1
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
And increase provisioning timeout.

This is cherry-pick of https://github.com/openshift/aws-efs-csi-driver-operator/pull/29 and https://github.com/openshift/aws-efs-csi-driver-operator/pull/28 to release-4.9. It should help with slow deletion of PVs.