### PR TITLE
Bug 2073006: Add all shipped architectures to CSV labels

### DIFF
--- a/config/manifests/4.11/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/4.11/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -18,6 +18,8 @@ metadata:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
     "operatorframework.io/arch.arm64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
 spec:
   displayName: AWS EFS CSI Driver Operator
   description: Operator that installs and configures the CSI driver for Amazon Elastic File System (AWS EFS).


### PR DESCRIPTION
We build & ship the operator + driver on all architectures, therefore announce them in the CSV. There are automatic jobs that watch if the images in registry match announced architectures.

cc @openshift/storage 