### PR TITLE
fix create-bundle manifest and bundle channel name

### DIFF
--- a/config/bundle.Dockerfile
+++ b/config/bundle.Dockerfile
@@ -3,7 +3,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=aws-efs-csi-driver-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=preview
-LABEL operators.operatorframework.io.bundle.channel.default.v1=preview
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 COPY manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml /manifests/aws-efs-csi-driver-operator.clusterserviceversion.yaml
 COPY metadata/annotations.yaml /metadata/annotations.yaml

--- a/config/metadata/annotations.yaml
+++ b/config/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: 4.11
-  operators.operatorframework.io.bundle.channels.v1: 4.11
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/hack/create-bundle
+++ b/hack/create-bundle
@@ -22,7 +22,7 @@ mkdir -p opm-bundle
 pushd opm-bundle
 cp -r -v ../../config/* .
 
-MANIFEST=manifests/4.11/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+MANIFEST=manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
 
 # Replace images in the manifest - error prone, needs to be in sync with image-references.
 sed -i $MANIFEST -e "s~quay.io/openshift/origin-aws-efs-csi-driver-operator:latest~$OPERATOR_IMAGE~" -e "s~quay.io/openshift/origin-aws-efs-csi-driver:latest~$DRIVER_IMAGE~"


### PR DESCRIPTION
This PR is a follow-up for https://github.com/openshift/aws-efs-csi-driver-operator/pull/41
- `hack/create-bundle` needs to point to the new CSV location
- `config/metadata/annotations.yaml` and `config/bundle.Dockerfile` should both use the same channel name to fix the pj-rehearse job in https://github.com/openshift/release/pull/28071

/cc @openshift/storage