### PR TITLE
Find suitable container tool

### DIFF
--- a/hack/create-bundle
+++ b/hack/create-bundle
@@ -12,6 +12,13 @@ if [ "$#" -ne "4" ]; then
     exit 1
 fi
 
+TOOL_BIN=$(which podman 2>/dev/null || which docker 2>/dev/null)
+if [ "$? " -ne "0" ]; then
+	echo "Error: No suitable container manipulation tool (podman, docker) found in \$PATH" 1>&2
+	exit 1
+fi
+
+TOOL_NAME=$(basename $TOOL_BIN)
 DRIVER_IMAGE=$1
 OPERATOR_IMAGE=$2
 BUNDLE_IMAGE=$3
@@ -28,12 +35,12 @@ MANIFEST=manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
 sed -i $MANIFEST -e "s~quay.io/openshift/origin-aws-efs-csi-driver-operator:latest~$OPERATOR_IMAGE~" -e "s~quay.io/openshift/origin-aws-efs-csi-driver:latest~$DRIVER_IMAGE~"
 
 # Build the bundle and push it
-docker build -t $BUNDLE_IMAGE -f bundle.Dockerfile .
-docker push $BUNDLE_IMAGE
+$TOOL_BIN build -t $BUNDLE_IMAGE -f bundle.Dockerfile .
+$TOOL_BIN push $BUNDLE_IMAGE
 
 # Build the index image and push it
-opm index add --bundles $BUNDLE_IMAGE --tag $INDEX_IMAGE --container-tool docker
-docker push $INDEX_IMAGE
+opm index add --bundles $BUNDLE_IMAGE --tag $INDEX_IMAGE --container-tool $TOOL_NAME
+$TOOL_BIN push $INDEX_IMAGE
 
 
 echo


### PR DESCRIPTION
Docker is deprecated: let's autodetect the installed container manipulation tool (podman or docker) and use that instead of failing if no `docker` command is found.