### PR TITLE
Bug 2094525: Fix lower bound of skip range to allow operator upgrades

### DIFF
--- a/config/manifests/art.yaml
+++ b/config/manifests/art.yaml
@@ -7,8 +7,8 @@ updates:
     # replace entire version line, otherwise would replace 4.3.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.9.0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.9.0 <{FULL_VER}"'
+    - search: 'olm.skipRange: ">=4.9.0-0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.9.0-0 <{FULL_VER}"'
   - file: "aws-efs-csi-driver-operator.package.yaml"
     update_list:
     - search: "currentCSV: aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0"

--- a/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
     repository: https://github.com/openshift/aws-efs-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
-    olm.skipRange: ">=4.9.0 <4.11.0"
+    olm.skipRange: ">=4.9.0-0 <4.11.0"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported


### PR DESCRIPTION
The reason we are updating this is because 4.9.0 is less than
4.9.0-2022xx and hence it must be updated to 4.9.0-0 so as an operator
on 4.9.0-2022x can be upgraded to 4.10 or 4.11

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2094525
