### PR TITLE
Bump to 4.13

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.13

--- a/config/manifests/aws-efs-csi-driver-operator.package.yaml
+++ b/config/manifests/aws-efs-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: aws-efs-csi-driver-operator
 channels:
 - name: stable
-  currentCSV: aws-efs-csi-driver-operator.v4.12.0
+  currentCSV: aws-efs-csi-driver-operator.v4.13.0

--- a/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: aws-efs-csi-driver-operator.v4.12.0
+  name: aws-efs-csi-driver-operator.v4.13.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,7 +13,7 @@ metadata:
     repository: https://github.com/openshift/aws-efs-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
-    olm.skipRange: ">=4.9.0-0 <4.12.0"
+    olm.skipRange: ">=4.9.0-0 <4.13.0"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
@@ -32,7 +32,7 @@ spec:
       url: https://github.com/openshift/aws-efs-csi-driver-operator
     - name: Source Repository
       url: https://github.com/openshift/aws-efs-csi-driver-operator
-  version: 4.12.0
+  version: 4.13.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -42,7 +42,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: aws-efs-csi-driver-operator
-    alm-status-descriptors: aws-efs-csi-driver-operator.v4.12.0
+    alm-status-descriptors: aws-efs-csi-driver-operator.v4.13.0
   selector:
     matchLabels:
       alm-owner-metering: aws-efs-csi-driver-operator


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-5087

Once version is bumped, the operator can be re-enabled in 4.13