### PR TITLE
fix naming convention

### DIFF
--- a/config/manifests/art.yaml
+++ b/config/manifests/art.yaml
@@ -3,7 +3,7 @@ updates:
     update_list:
     # replace metadata.name value
     - search: "aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0"
-      replace: "aws-efs-csi-driver-operator.{FULL_VER}"
+      replace: "aws-efs-csi-driver-operator.v{FULL_VER}"
     # replace entire version line, otherwise would replace 4.3.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
`Warning: Value : (aws-efs-csi-driver-operator.4.12.0-202211081106) csv.metadata.Name aws-efs-csi-driver-operator.4.12.0-202211081106 is not following the recommended naming convention: <operator-name>.v<semver> e.g. memcached-operator.v0.`
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-aws-efs-csi-driver-operator-bundle-container-v4.12.0.202211081106.p0.gcc89dfb.assembly.stream-1/f50f2262-fd52-45b2-9c30-5ef17893ef1b/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.