### PR TITLE
Bug 2106736: Add multiplePVsSameID capability

### DIFF
--- a/assets/testing/manifest.yaml
+++ b/assets/testing/manifest.yaml
@@ -18,4 +18,4 @@ DriverInfo:
     snapshotDataSource: false
     RWX: true
     topology: false
-
+    multiplePVsSameID: true


### PR DESCRIPTION
This CSI driver can handle multiple PVs that have the same VolumeHandle used on the same node.

cc @openshift/storage 