### PR TITLE
STOR-1303: Restart controller Pods if metrics-serving-cert changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ EOF
 make
 
 # Set the environment variables
-export DRIVER_IMAGE=amazon/aws-efs-csi-driver:v1.1.1
+export DRIVER_IMAGE=quay.io/openshift/origin-aws-efs-csi-driver:latest
 export NODE_DRIVER_REGISTRAR_IMAGE=quay.io/openshift/origin-csi-node-driver-registrar:latest
-export LIVENESS_PROBE_IMAGE=quay.io/openshift/origin-csi-livenessprobe:4.8
+export LIVENESS_PROBE_IMAGE=quay.io/openshift/origin-csi-livenessprobe:latest
 export OPERATOR_NAME=aws-efs-csi-driver-operator
+export PROVISIONER_IMAGE=quay.io/openshift/origin-csi-external-provisioner:latest
+export KUBE_RBAC_PROXY_IMAGE=quay.io/openshift/origin-kube-rbac-proxy:latest
 
 # Run the operator via CLI
 ./aws-efs-csi-driver-operator start --kubeconfig $KUBECONFIG --namespace openshift-cluster-csi-drivers

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -37,7 +37,9 @@ const (
 
 	namespaceReplaceKey = "${NAMESPACE}"
 	// From credentials.yaml
-	secretName = "aws-efs-cloud-credentials"
+	cloudCredSecretName = "aws-efs-cloud-credentials"
+	// From controller.yaml
+	metricsCertSecretName = "aws-efs-csi-driver-controller-metrics-serving-cert"
 )
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
@@ -107,7 +109,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			trustedCAConfigMap,
 			configMapInformer,
 		),
-		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(operatorNamespace, secretName, secretInformer),
+		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(operatorNamespace, cloudCredSecretName, secretInformer),
+		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(operatorNamespace, metricsCertSecretName, secretInformer),
 		csidrivercontrollerservicecontroller.WithObservedProxyDeploymentHook(),
 		csidrivercontrollerservicecontroller.WithReplicasHook(nodeInformer.Lister()),
 	).WithCredentialsRequestController(


### PR DESCRIPTION
Adding WithSecretHashAnnotationHook() for aws-ebs-csi-driver-controller-metrics-serving-cert ensures that new annotation is published in aws-ebs-csi-driver-controller deployment. This, in turn, leads to controller pods restart.

The PR also piggybacks cosmetic changes to README.md: 1) Define env var `PROVISIONER_IMAGE` and `KUBE_RBAC_PROXY_IMAGE` 2) Update env var `LIVENESS_PROBE_IMAGE` to use latest version of the image 3) Update env var `DRIVER_IMAGE` to use latest version of the image from quay.io