### PR TITLE
STOR-1376: Add STS support

### DIFF
--- a/assets/credentials.yaml
+++ b/assets/credentials.yaml
@@ -15,3 +15,4 @@ spec:
       action:
       - elasticfilesystem:*
       resource: "*"
+  # STS fields will be set by the operator

--- a/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -14,6 +14,7 @@ metadata:
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
     olm.skipRange: ">=4.9.0-0 <4.14.0"
+    features.operators.openshift.io/token-auth-aws: "true"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20230613151523-ba04973d3ed1
 	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb
-	github.com/openshift/library-go v0.0.0-20230626162119-954ade536d6d
+	github.com/openshift/library-go v0.0.0-20230714173235-d8d3f3f8a9e4
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/net v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533 h1:mh
 github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb h1:Nij5OnaECrkmcRQMAE9LMbQXPo95aqFnf+12B7SyFVI=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb/go.mod h1:Rhb3moCqeiTuGHAbXBOlwPubUMlOZEkrEWTRjIF3jzs=
-github.com/openshift/library-go v0.0.0-20230626162119-954ade536d6d h1:RXJqcNJPjUFlZA27J2fbL7KVMBUvhPxWiH3YkSjrR7w=
-github.com/openshift/library-go v0.0.0-20230626162119-954ade536d6d/go.mod h1:PegtilvJPBJXjJG3AV8uL1a0SAnBr6K67ShNiWVb40M=
+github.com/openshift/library-go v0.0.0-20230714173235-d8d3f3f8a9e4 h1:iIlpi144jZqPBPs6542Lz4p9MAPi/s5PLQ4XVxzXRwU=
+github.com/openshift/library-go v0.0.0-20230714173235-d8d3f3f8a9e4/go.mod h1:PegtilvJPBJXjJG3AV8uL1a0SAnBr6K67ShNiWVb40M=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -140,6 +140,7 @@ func (c *CSIControllerSet) WithCredentialsRequestController(
 	file string,
 	dynamicClient dynamic.Interface,
 	operatorInformer operatorinformer.SharedInformerFactory,
+	hooks ...credentialsrequestcontroller.CredentialsRequestHook,
 ) *CSIControllerSet {
 	manifestFile, err := assetFunc(file)
 	if err != nil {
@@ -153,6 +154,7 @@ func (c *CSIControllerSet) WithCredentialsRequestController(
 		c.operatorClient,
 		operatorInformer,
 		c.eventRecorder,
+		hooks...,
 	)
 	return c
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -318,7 +318,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20230626162119-954ade536d6d
+# github.com/openshift/library-go v0.0.0-20230714173235-d8d3f3f8a9e4
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
See https://github.com/openshift/enhancements/blob/master/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md

STS (or any token authentication mode) is determined by presence of env. var `ROLEARN`. If it's set, then the operator files `stsIAMRoleARN` and `cloudTokenPath` in the CredentialsRequest. Otherwise it sets them `""`, which is the empty value (they're not pointers).

CCO should do the rest.
