### PR TITLE
OCPBUGS-17244: Fix links to documentation

### DIFF
--- a/config/manifests/art.yaml
+++ b/config/manifests/art.yaml
@@ -11,7 +11,7 @@ updates:
       replace: 'olm.skipRange: ">=4.9.0-0 <{FULL_VER}"'
     # Update links in the CSV description to exact OCP version
     - search: 'https://docs.openshift.com/container-platform/latest/'
-      replace: 'https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}'
+      replace: 'https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}/'
   - file: "aws-efs-csi-driver-operator.package.yaml"
     update_list:
     - search: "currentCSV: aws-efs-csi-driver-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
Replace `latest/` with `4.14/`, with the ending slash.

@openshift/storage 