### PR TITLE
[4.12] OCPBUGS-18417: set TLS cipher suites in Kube RBAC sidecars

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -141,6 +141,7 @@ spec:
           - --upstream=http://127.0.0.1:8212/
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
+          - --tls-cipher-suites=${TLS_CIPHER_SUITES}
           - --logtostderr=true
           image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20220919112502-5eaf4250c423
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e
-	github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865
+	github.com/openshift/library-go v0.0.0-20221107174711-e25f9d9b5311
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e h1:ab+BJg7h50pi2/rbMkDSXfYx8w80HLmr7NBs8H1hEvU=
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e/go.mod h1:e+TTiBDGWB3O3p3iAzl054x3cZDWhrZ5+jxJRCdEFkA=
-github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865 h1:x7KWaYzkD2KQ3rha9u7OVAfjZpSFTmJRSHb4CHc+CwM=
-github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
+github.com/openshift/library-go v0.0.0-20221107174711-e25f9d9b5311 h1:5pvnCPDAcNV3TnXabaXRmlAgkLPZiM5MKhJ/A0KZq0Q=
+github.com/openshift/library-go v0.0.0-20221107174711-e25f9d9b5311/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -269,7 +269,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 	var server *genericapiserver.GenericAPIServer
 	if b.servingInfo != nil {
-		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig)
+		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -50,6 +50,12 @@ import (
 // The placeholders ${LEADER_ELECTION_LEASE_DURATION}, ${LEADER_ELECTION_RENEW_DEADLINE} and ${LEADER_ELECTION_RETRY_PERIOD}
 // are replaced with OpenShift's recommended parameters for leader election.
 //
+// 5. TLS Cipher Suites
+//
+// The placeholder ${TLS_CIPHER_SUITES} is replaced with recommended OCP defaults.
+// These are primarily meant for Kube RBAC sidecars, which may allow some insecure
+// ciphers unless the --tls-cipher-suites argument is explictly provided.
+//
 // This controller supports removable operands, as configured in pkg/operator/management.
 //
 // This controller produces the following conditions:

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
@@ -32,6 +32,8 @@ const (
 	livenessProbeImageEnvName = "LIVENESS_PROBE_IMAGE"
 	kubeRBACProxyImageEnvName = "KUBE_RBAC_PROXY_IMAGE"
 
+	defaultTLSCipherSuites = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"
+
 	infraConfigName = "cluster"
 )
 
@@ -187,6 +189,9 @@ func WithPlaceholdersHook(configInformer configinformers.SharedInformerFactory) 
 		// Log level
 		logLevel := loglevel.LogLevelToVerbosity(spec.LogLevel)
 		pairs = append(pairs, []string{"${LOG_LEVEL}", strconv.Itoa(logLevel)}...)
+
+		// Default TLS Cipher Suites for Kube RBAC sidecars
+		pairs = append(pairs, []string{"${TLS_CIPHER_SUITES}", defaultTLSCipherSuites}...)
 
 		replaced := strings.NewReplacer(pairs...).Replace(string(manifest))
 		return []byte(replaced), nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -368,7 +368,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 }
 
 func (c *StaticResourceController) Name() string {
-	return "StaticResourceController"
+	return c.name
 }
 
 func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -290,7 +290,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865
+# github.com/openshift/library-go v0.0.0-20221107174711-e25f9d9b5311
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-18417

- Bump library-go to get default TLS cipher suite list
- OCPBUGS-18417: set TLS cipher suites in Kube RBAC sidecars

cc @openshift/storage
