### PR TITLE
STOR-1590: Bump OLM metadata to 4.16

### DIFF
--- a/Dockerfile.create_efs
+++ b/Dockerfile.create_efs
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/aws-efs-csi-driver-operator
 COPY . .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.15:base
+FROM registry.ci.openshift.org/ocp/4.16:base
 COPY --from=builder /go/src/github.com/openshift/aws-efs-csi-driver-operator/create-efs-volume /usr/bin/
 ENTRYPOINT ["/usr/bin/create-efs-volume"]
 LABEL io.k8s.display-name="OpenShift AWS EFS Creator" \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: build
 .PHONY: all
 
 # This variable affects which manifest directory is used/updated.
-MINORVERSION?=4.15
+MINORVERSION?=4.16
 
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
@@ -27,7 +27,7 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,aws-efs-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.15:aws-efs-csi-driver-operator,./Dockerfile,.)
+$(call build-image,aws-efs-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.16:aws-efs-csi-driver-operator,./Dockerfile,.)
 
 clean:
 	$(RM) aws-efs-csi-driver-operator

--- a/config/manifests/aws-efs-csi-driver-operator.package.yaml
+++ b/config/manifests/aws-efs-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: aws-efs-csi-driver-operator
 channels:
 - name: stable
-  currentCSV: aws-efs-csi-driver-operator.v4.15.0
+  currentCSV: aws-efs-csi-driver-operator.v4.16.0

--- a/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: aws-efs-csi-driver-operator.v4.15.0
+  name: aws-efs-csi-driver-operator.v4.16.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,7 +13,7 @@ metadata:
     repository: https://github.com/openshift/aws-efs-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
-    olm.skipRange: ">=4.9.0-0 <4.15.0"
+    olm.skipRange: ">=4.9.0-0 <4.16.0"
     features.operators.openshift.io/token-auth-aws: "true"
   labels:
     operator-metering: "true"
@@ -43,7 +43,7 @@ spec:
       url: https://github.com/openshift/aws-efs-csi-driver-operator
     - name: Source Repository
       url: https://github.com/openshift/aws-efs-csi-driver-operator
-  version: 4.15.0
+  version: 4.16.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -53,7 +53,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: aws-efs-csi-driver-operator
-    alm-status-descriptors: aws-efs-csi-driver-operator.v4.15.0
+    alm-status-descriptors: aws-efs-csi-driver-operator.v4.16.0
   selector:
     matchLabels:
       alm-owner-metering: aws-efs-csi-driver-operator


### PR DESCRIPTION
Increase OCP version in OLM metadata.

In addition, bump Dockerfile.create_efs to 4.16 images, because they're not updated by ART scripts.

@openshift/storage 