### PR TITLE
OCPBUGS-28551: Remove CPU limits from the driver container

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -105,7 +105,6 @@ spec:
             # intended to prevent the driver from adding undue stress to control-plane nodes.
             limits:
               memory: 1Gi
-              cpu: 100m
           # external-provisioner container
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -80,7 +80,6 @@ spec:
             # intended to prevent the driver from adding undue stress to control-plane nodes.
             limits:
               memory: 1Gi
-              cpu: 100m
         - name: csi-node-driver-registrar
           securityContext:
             privileged: true


### PR DESCRIPTION
Remove the CPU limits from the node driver to prevent stunnel throttling.
https://issues.redhat.com/browse/OCPBUGS-28551