### PR TITLE
OCPBUGS-29070: Add feature annotations to CSV

### DIFF
--- a/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -14,7 +14,15 @@ metadata:
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
     olm.skipRange: ">=4.9.0-0 <4.16.0"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/csi: "true"
     features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported


### PR DESCRIPTION
Add all required feature annotations to the operator. See the bug for our internal test report.

I am skipping the optional ones (`cnv`, `cnf`), I think `false` is implied there.

@openshift/storage 