### PR TITLE
OCPBUGS-30113: 4.13: Add feature annotations to CSV

### DIFF
--- a/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -14,6 +14,16 @@ metadata:
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
     olm.skipRange: ">=4.9.0-0 <4.13.0"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false" # requires OCP 4.15
+    features.operators.openshift.io/csi: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    # Operator does NOT support configuration for tokenzied authentication by using the Cloud Credential Operator (CCO), that's a 4.14 feature.
+    # Users must use ccoctl manually.
+    features.operators.openshift.io/token-auth-aws: "false"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported


### PR DESCRIPTION
Add all required feature annotations to the operator.
This is a manual cherry-pick of https://github.com/openshift/aws-efs-csi-driver-operator/pull/127 to 4.13.
In 4.13, we do not support "tokenized authentication with AWS APIs via AWS Secure Token Service (STS) by using the Cloud Credential Operator (CCO)", that was added as 4.14 feature https://issues.redhat.com/browse/STOR-1347

@openshift/storage 