### PR TITLE
STOR-1856: Mark the repository as obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!warning]
+> **This repo is obsolete in OCP 4.17.**
+> AWS EFS CSI driver operator in 4.17 and newer is built from https://github.com/openshift/csi-operator.
+> 4.16 and older branches in this repo are still in use, until EOL of the corresponding OCP version.
+> See [this enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-driver-operator-merge.md) for details.
+
 # aws-efs-csi-driver operator
 
 An operator to deploy the [AWS EFS CSI driver](https://github.com/openshift/aws-efs-csi-driver) in OKD.


### PR DESCRIPTION
Add a warning that this repo is no longer used in 4.17 and newer.

cc @openshift/storage 