### PR TITLE
STOR-1856: add permissions for poddisruptionbudgets to CSV

### DIFF
--- a/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -104,6 +104,18 @@ spec:
             - servicemonitors
             verbs:
             - '*'
+          - apiGroups:
+              - policy
+            resources:
+              - poddisruptionbudgets
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
           serviceAccountName: aws-efs-csi-driver-operator
       clusterPermissions:
         - rules:


### PR DESCRIPTION
Posting this patch to this legacy repo intentionally for the sake of consistency with efs operator legacy files in csi-operator where this fix is applied.