### PR TITLE
OCPBUGS-37274: Add FIPS_ENABLED to env vars for aws-efs-csi-driver

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -72,6 +72,8 @@ spec:
               value: '1'
             - name: AWS_CONFIG_FILE
               value: /var/run/secrets/aws/credentials
+            - name: FIPS_ENABLED
+              value: ${FIPS_ENABLED}
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node!

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -43,6 +43,8 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: FIPS_ENABLED
+              value: ${FIPS_ENABLED}
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet


### PR DESCRIPTION
https://github.com/openshift/aws-efs-csi-driver/pull/80 will use `FIPS_ENABLED` to create proper config file for stunnel.