### PR TITLE
OCPBUGS-37590: Add FIPS_ENABLED to env vars for aws-efs-csi-driver

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -28,7 +28,10 @@ import (
 	operatorinformer "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/csi/csicontrollerset"
+	dc "github.com/openshift/library-go/pkg/operator/deploymentcontroller"
 	goc "github.com/openshift/library-go/pkg/operator/genericoperatorclient"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -96,7 +99,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			operatorNamespace,
 			trustedCAConfigMap,
 			configMapInformer,
-		)).WithCSIDriverControllerService(
+		),
+		withFIPSDaemonSetHook()).WithCSIDriverControllerService(
 		"AWSEFSDriverControllerServiceController",
 		replaceNamespaceFunc(operatorNamespace),
 		"controller.yaml",
@@ -117,6 +121,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(operatorNamespace, metricsCertSecretName, secretInformer),
 		csidrivercontrollerservicecontroller.WithObservedProxyDeploymentHook(),
 		csidrivercontrollerservicecontroller.WithReplicasHook(nodeInformer.Lister()),
+		withFIPSDeploymentHook(),
 	).WithCredentialsRequestController(
 		"AWSEFSDriverCredentialsRequestController",
 		operatorNamespace,
@@ -207,4 +212,52 @@ func stsCredentialsRequestHook(spec *opv1.OperatorSpec, cr *unstructured.Unstruc
 		return err
 	}
 	return nil
+}
+
+func getFIPSEnabled() string {
+	content, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
+	if err == nil && string(content) == "1\n" {
+		return "true"
+	}
+	return "false"
+}
+
+func withFIPSDeploymentHookInternal(fipsEnbaled string) dc.DeploymentHookFunc {
+	return func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		for i := range deployment.Spec.Template.Spec.Containers {
+			container := &deployment.Spec.Template.Spec.Containers[i]
+			if container.Name != "csi-driver" {
+				continue
+			}
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  "FIPS_ENABLED",
+				Value: fipsEnbaled,
+			})
+		}
+		return nil
+	}
+}
+
+func withFIPSDeploymentHook() dc.DeploymentHookFunc {
+	return withFIPSDeploymentHookInternal(getFIPSEnabled())
+}
+
+func withFIPSDaemonSetHookInternal(fipsEnbaled string) csidrivernodeservicecontroller.DaemonSetHookFunc {
+	return func(_ *opv1.OperatorSpec, daemonSet *appsv1.DaemonSet) error {
+		for i := range daemonSet.Spec.Template.Spec.Containers {
+			container := &daemonSet.Spec.Template.Spec.Containers[i]
+			if container.Name != "csi-driver" {
+				continue
+			}
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  "FIPS_ENABLED",
+				Value: fipsEnbaled,
+			})
+		}
+		return nil
+	}
+}
+
+func withFIPSDaemonSetHook() csidrivernodeservicecontroller.DaemonSetHookFunc {
+	return withFIPSDaemonSetHookInternal(getFIPSEnabled())
 }

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,138 @@
+package operator
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/aws-efs-csi-driver-operator/assets"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func getTestDeployment() *appsv1.Deployment {
+	data, err := assets.ReadFile("controller.yaml")
+	if err != nil {
+		panic(err)
+	}
+	return resourceread.ReadDeploymentV1OrDie(data)
+}
+
+func getTestDaemonSet() *appsv1.DaemonSet {
+	data, err := assets.ReadFile("node.yaml")
+	if err != nil {
+		panic(err)
+	}
+	return resourceread.ReadDaemonSetV1OrDie(data)
+}
+
+func Test_WithFIPSDeploymentHook(t *testing.T) {
+	tests := []struct {
+		name            string
+		fipsEnabled     string
+		expectedEnvVars map[string]string
+	}{
+		{
+			name:        "FIPS enabled",
+			fipsEnabled: "true",
+			expectedEnvVars: map[string]string{
+				"FIPS_ENABLED": "true",
+			},
+		},
+		{
+			name:        "FIPS disabled",
+			fipsEnabled: "false",
+			expectedEnvVars: map[string]string{
+				"FIPS_ENABLED": "false",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := getTestDeployment()
+
+			// Act
+			err := withFIPSDeploymentHookInternal(tt.fipsEnabled)(nil, deployment)
+			if err != nil {
+				t.Fatalf("unexpected hook error: %v", err)
+			}
+
+			// Assert
+			found := false
+			for _, container := range deployment.Spec.Template.Spec.Containers {
+				if container.Name == "csi-driver" {
+					// Collect FIPS_ENABLED from struct EnvVar to map[string]string
+					containerEnvs := map[string]string{}
+					for _, env := range container.Env {
+						if env.Name == "FIPS_ENABLED" {
+							containerEnvs[env.Name] = env.Value
+						}
+					}
+					if !reflect.DeepEqual(containerEnvs, tt.expectedEnvVars) {
+						t.Errorf("expected csi-driver env var %+v, got %+v", tt.expectedEnvVars, containerEnvs)
+					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("container csi-driver not found")
+			}
+		})
+	}
+}
+
+func Test_WithFIPSDaemonSetHook(t *testing.T) {
+	tests := []struct {
+		name            string
+		fipsEnabled     string
+		expectedEnvVars map[string]string
+	}{
+		{
+			name:        "FIPS enabled",
+			fipsEnabled: "true",
+			expectedEnvVars: map[string]string{
+				"FIPS_ENABLED": "true",
+			},
+		},
+		{
+			name:        "FIPS disabled",
+			fipsEnabled: "false",
+			expectedEnvVars: map[string]string{
+				"FIPS_ENABLED": "false",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			daemonSet := getTestDaemonSet()
+
+			// Act
+			err := withFIPSDaemonSetHookInternal(tt.fipsEnabled)(nil, daemonSet)
+			if err != nil {
+				t.Fatalf("unexpected hook error: %v", err)
+			}
+
+			// Assert
+			found := false
+			for _, container := range daemonSet.Spec.Template.Spec.Containers {
+				if container.Name == "csi-driver" {
+					// Collect FIPS_ENABLED from struct EnvVar to map[string]string
+					containerEnvs := map[string]string{}
+					for _, env := range container.Env {
+						if env.Name == "FIPS_ENABLED" {
+							containerEnvs[env.Name] = env.Value
+						}
+					}
+					if !reflect.DeepEqual(containerEnvs, tt.expectedEnvVars) {
+						t.Errorf("expected csi-driver env var %+v, got %+v", tt.expectedEnvVars, containerEnvs)
+					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("container csi-driver not found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Manual "cherry-pick" of [`a4f3e81473`](https://github.com/openshift/csi-operator/commit/a4f3e81473bfa82bc301c3c82883d0b981e543aa) from https://github.com/openshift/csi-operator.git for 4.16